### PR TITLE
Fix broken link to metrics

### DIFF
--- a/docs/documentation/sitespeed.io/index.md
+++ b/docs/documentation/sitespeed.io/index.md
@@ -34,7 +34,7 @@ Sitespeed.io is the complete toolbox to test the web performance of your web sit
  * [Axe](axe/) - run accessibility tests.
  * [Continuous Integration](continuous-integration/) - generate JUnit XML/TAP and use Jenkins, Circle CI, Gitlab CI, GitHub Actions, Grunt or the Gulp plugin.
  * [Configure HTML output](configure-html/) - change the default HTML output.
- * [Configure Metrics](configure-metrics/) - configure which metrics you want to send to Graphite/InfluxDB.
+ * [Configure Metrics](metrics/) - configure which metrics you want to send to Graphite/InfluxDB.
  * [CPU](cpu/) - measure CPU metrics to see where your page spends the time.
  * [Developers](developers/) - start here when you want to do PRs or create a plugin.
  * [Graphite](graphite/) - how to configure and store your metrics in Graphite (and using StatsD).


### PR DESCRIPTION
Fixes #2837

Link to `configure-metrics/` was added in #2790 but the documentation on how to configure metrics is still at `metrics/`
